### PR TITLE
Bugfixed missing alt+shift layer in XKB files

### DIFF
--- a/src/xkb/convert.rs
+++ b/src/xkb/convert.rs
@@ -96,7 +96,7 @@ fn collect_keys(key_map: &DesktopModes, _default: Option<&Symbols>) -> Result<Ve
         .ok_or(Error::NoDefaultKeyMap)?;
     let shift = key_map.get("shift").cloned().unwrap_or_default();
     let alt = key_map.get("alt").cloned().unwrap_or_default();
-    let alt_shift = key_map.get("alt_shift").cloned().unwrap_or_default();
+    let alt_shift = key_map.get("alt+shift").cloned().unwrap_or_default();
 
     let mut res = Vec::new();
 


### PR DESCRIPTION
String error caused them to not be picked up. Now they are entered
as intended.